### PR TITLE
Package with Nix and flakes

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,22 @@
+{ buildGoModule
+, fetchFromGitHub
+, lib
+}:
+
+let
+  # Finds version definition in main.go
+  text = builtins.readFile ./main.go;
+  sanitizedText = lib.stringAsChars (x: if x == "\t" || x == "\"" then "" else x) text;
+  linesList = lib.splitString "\n" sanitizedText;
+  versionDefinition = lib.findFirst (x: lib.hasInfix "version" x) "version = 1.0" linesList;
+  verDefWordsList = lib.splitString " " versionDefinition;
+  version = lib.last verDefWordsList;
+in
+buildGoModule {
+  pname = "age-edit";
+  inherit version;
+
+  src = ./.;
+
+  vendorHash = "sha256-KSs+zYcF5xIJh0oD04OQ977EmRIz4EiYvrw+TUnW/sw=";
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,25 @@
+{
+  description = "Editor wrapper for files encrypted with age.";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils, ... }:
+    flake-utils.lib.eachDefaultSystem (system:
+    let
+      pkgs = import nixpkgs { inherit system; };
+    in
+    {
+      packages = {
+        age-edit = pkgs.callPackage ./. { };
+        default = self.packages.${system}.age-edit;
+      };
+    })
+    // {
+      overlays.default = final: prev: {
+        inherit (self.packages.${final.system}) age-edit;
+      };
+    };
+}


### PR DESCRIPTION
Version string is automatically taken from "version = x.x.x" definition in main.go.
**However vendorHash in default.nix needs to be manually updated**. It is [possible](https://nixos.org/manual/nixpkgs/stable/#var-go-vendorHash) to do 'go mod vendor' and set vendorHash to null to avoid dealing with this though.

The following can (roughly) be added to README:
- Can be run with `nix run github:dbohdan/age-edit` without installing
  Use double dashes before age-edit arguments: `nix run github:dbohdan/age-edit -- --no-memlock ...`
- Or installed with [flakes](https://nixos.wiki/wiki/Flakes):
```nix
{
  # add age-edit flake to your inputs
  inputs.age-edit = {
    url = "github:dbohdan/age-edit";
    inputs.nixpkgs.follows = "nixpkgs";
  };

  # ensure that age-edit is an allowed argument to the outputs function
  outputs = { self, nixpkgs, age-edit }: {
    nixosConfigurations.yourHostName = nixpkgs.lib.nixosSystem {
      modules = [
        ({ pkgs, ... }: {
          # add the age-edit overlay to make the package available through pkgs
          nixpkgs.overlays = [ age-edit.overlays.default ];

          # install the package globally
          environment.systemPackages = [ pkgs.age-edit ];
        })
      ];
    };
  };
}
```